### PR TITLE
chore: add types to exports mapping

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "exports": {
     ".": {
       "require": "./dist/index.js",
-      "import": "./dist/index.mjs"
+      "import": "./dist/index.mjs",
+      "types": "./dist/index.d.ts"
     }
   },
   "funding": "https://github.com/sponsors/antfu",


### PR DESCRIPTION
This is required for `nodenext` module resolution.