### PR TITLE
feat: replace ezspawn with tinyexec

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,9 +43,6 @@
     "release": "bumpp --commit --push --tag && pnpm publish",
     "lint": "eslint ."
   },
-  "dependencies": {
-    "@jsdevtools/ez-spawn": "^3.0.4"
-  },
   "devDependencies": {
     "@antfu/eslint-config": "^2.16.0",
     "@antfu/ni": "^0.21.12",
@@ -57,5 +54,8 @@
     "publint": "^0.2.7",
     "tsup": "^8.0.2",
     "typescript": "^5.4.5"
+  },
+  "dependencies": {
+    "tinyexec": "^0.1.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,9 @@ importers:
 
   .:
     dependencies:
-      '@jsdevtools/ez-spawn':
-        specifier: ^3.0.4
-        version: 3.0.4
+      tinyexec:
+        specifier: ^0.1.2
+        version: 0.1.2
     devDependencies:
       '@antfu/eslint-config':
         specifier: ^2.16.0
@@ -1821,6 +1821,9 @@ packages:
 
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  tinyexec@0.1.2:
+    resolution: {integrity: sha512-aVXhKcB7XIe0zjjpVhU9vJ7AAPF8VsGpzx0IpmVeYLILRZUWcEQ4Pq/dnUodF5cAYZohjzCP1HkC8hChqZ3pNA==}
 
   to-fast-properties@2.0.0:
     resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
@@ -3817,6 +3820,8 @@ snapshots:
   thenify@3.3.1:
     dependencies:
       any-promise: 1.3.0
+
+  tinyexec@0.1.2: {}
 
   to-fast-properties@2.0.0: {}
 

--- a/src/install.ts
+++ b/src/install.ts
@@ -1,7 +1,7 @@
 import { existsSync } from 'node:fs'
 import process from 'node:process'
 import { resolve } from 'node:path'
-import { async as ezspawn } from '@jsdevtools/ez-spawn'
+import { x } from 'tinyexec'
 import { detectPackageManager } from '.'
 
 export interface InstallPackageOptions {
@@ -34,7 +34,7 @@ export async function installPackage(names: string | string[], options: InstallP
   if (agent === 'pnpm' && existsSync(resolve(options.cwd ?? process.cwd(), 'pnpm-workspace.yaml')))
     args.unshift('-w')
 
-  return ezspawn(
+  return x(
     agent,
     [
       agent === 'yarn'
@@ -45,8 +45,10 @@ export async function installPackage(names: string | string[], options: InstallP
       ...names,
     ].filter(Boolean),
     {
-      stdio: options.silent ? 'ignore' : 'inherit',
-      cwd: options.cwd,
+      nodeOptions: {
+        stdio: options.silent ? 'ignore' : 'inherit',
+        cwd: options.cwd,
+      },
     },
   )
 }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

https://npmgraph.js.org/?q=@jsdevtools/ez-spawn - 9 dependencies
https://npmgraph.js.org/?q=tinyexec - 0 dependencies

`@jsdevtools/ez-spawn` also has not been updated in 4 years

### Linked Issues

See https://github.com/antfu/install-pkg/pull/11#issuecomment-2273764981

### Additional context

`vitest` would like to switch to `tinyexec`, but they use this library so are waiting for it to be switched first so that they can keep dependencies in sync