### PR TITLE
feat: switch to updated version of tinyexec

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@jsdevtools/ez-spawn": "^3.0.4"
+    "tinyexec": "^0.2.0"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^2.25.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,9 @@ importers:
 
   .:
     dependencies:
-      '@jsdevtools/ez-spawn':
-        specifier: ^3.0.4
-        version: 3.0.4
+      tinyexec:
+        specifier: ^0.2.0
+        version: 0.2.0
     devDependencies:
       '@antfu/eslint-config':
         specifier: ^2.25.1
@@ -20,7 +20,7 @@ importers:
         version: 0.22.4
       '@types/node':
         specifier: ^22.3.0
-        version: 22.3.0
+        version: 22.4.1
       bumpp:
         specifier: ^9.5.1
         version: 9.5.1
@@ -632,8 +632,8 @@ packages:
   '@types/mdast@3.0.15':
     resolution: {integrity: sha512-LnwD+mUEfxWMa1QpDraczIn6k0Ee3SMicuYSSzS6ZYl2gKS09EClnJYGd8Du6rfc5r/GZEk5o1mRb8TaTj03sQ==}
 
-  '@types/node@22.3.0':
-    resolution: {integrity: sha512-nrWpWVaDZuaVc5X84xJ0vNrLvomM205oQyLsRt7OHNZbSHslcWsvgFR7O7hire2ZonjLrWBbedmotmIlJDVd6g==}
+  '@types/node@22.4.1':
+    resolution: {integrity: sha512-1tbpb9325+gPnKK0dMm+/LMriX0vKxf6RnB0SZUqfyVkQ4fMgUSySqhxE/y8Jvs4NyF1yHzTfG9KlnkIODxPKg==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -2100,6 +2100,9 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  tinyexec@0.2.0:
+    resolution: {integrity: sha512-au8dwv4xKSDR+Fw52csDo3wcDztPdne2oM1o/7LFro4h6bdFmvyUAeAfX40pwDtzHgRFqz1XWaUqgKS2G83/ig==}
+
   to-fast-properties@2.0.0:
     resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
     engines: {node: '>=4'}
@@ -2183,8 +2186,8 @@ packages:
   ufo@1.5.3:
     resolution: {integrity: sha512-Y7HYmWaFwPUmkoQCUIAYpKqkOf+SbVj/2fJJZ4RJMCfZp0rTGwRbzQD+HghfnhKOjL9E01okqz+ncJskGYfBNw==}
 
-  undici-types@6.18.2:
-    resolution: {integrity: sha512-5ruQbENj95yDYJNS3TvcaxPMshV7aizdv/hWYjGIKoANWKjhWNBsr2YEuYZKodQulB1b8l7ILOuDQep3afowQQ==}
+  undici-types@6.19.8:
+    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
 
   unicorn-magic@0.1.0:
     resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
@@ -2721,9 +2724,9 @@ snapshots:
     dependencies:
       '@types/unist': 2.0.10
 
-  '@types/node@22.3.0':
+  '@types/node@22.4.1':
     dependencies:
-      undici-types: 6.18.2
+      undici-types: 6.19.8
 
   '@types/normalize-package-data@2.4.4': {}
 
@@ -4306,6 +4309,8 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  tinyexec@0.2.0: {}
+
   to-fast-properties@2.0.0: {}
 
   to-regex-range@5.0.1:
@@ -4380,7 +4385,7 @@ snapshots:
 
   ufo@1.5.3: {}
 
-  undici-types@6.18.2: {}
+  undici-types@6.19.8: {}
 
   unicorn-magic@0.1.0: {}
 

--- a/src/install.ts
+++ b/src/install.ts
@@ -1,7 +1,7 @@
 import { existsSync } from 'node:fs'
 import process from 'node:process'
 import { resolve } from 'node:path'
-import { async as ezspawn } from '@jsdevtools/ez-spawn'
+import { x } from 'tinyexec'
 import { detectPackageManager } from './detect'
 
 export interface InstallPackageOptions {
@@ -34,7 +34,7 @@ export async function installPackage(names: string | string[], options: InstallP
   if (agent === 'pnpm' && existsSync(resolve(options.cwd ?? process.cwd(), 'pnpm-workspace.yaml')))
     args.unshift('-w')
 
-  return ezspawn(
+  return x(
     agent,
     [
       agent === 'yarn'
@@ -45,8 +45,10 @@ export async function installPackage(names: string | string[], options: InstallP
       ...names,
     ].filter(Boolean),
     {
-      stdio: options.silent ? 'ignore' : 'inherit',
-      cwd: options.cwd,
+      nodeOptions: {
+        stdio: options.silent ? 'ignore' : 'inherit',
+        cwd: options.cwd,
+      },
     },
   )
 }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Originally submitted in https://github.com/antfu/install-pkg/pull/12 and then reverted in e50016c9e4002cbb2d497dbdefe11fa0d53df6b0. This reverts the revert to try again with a fixed version of `tinyexec`.

https://npmgraph.js.org/?q=@jsdevtools/ez-spawn - 9 dependencies
https://npmgraph.js.org/?q=tinyexec - 0 dependencies

`@jsdevtools/ez-spawn` also has not been updated in 4 years

### Linked Issues

See https://github.com/antfu/install-pkg/pull/11#issuecomment-2273764981

### Additional context

`vitest` would like to switch to `tinyexec`, but they use this library so are waiting for it to be switched first so that they can keep dependencies in sync