### PR TITLE
chore: remove unused `packageManagerVersion` option

### DIFF
--- a/src/install.ts
+++ b/src/install.ts
@@ -9,7 +9,6 @@ export interface InstallPackageOptions {
   dev?: boolean
   silent?: boolean
   packageManager?: string
-  packageManagerVersion?: string
   preferOffline?: boolean
   additionalArgs?: string[]
 }


### PR DESCRIPTION
### Description

The `packageManagerVersion` option introduced in https://github.com/antfu-collective/install-pkg/pull/3 is not used and was probably forgotten to be removed