### PR TITLE
fix: prevent pnpm from removing dev deps while in production

### DIFF
--- a/src/install.ts
+++ b/src/install.ts
@@ -30,8 +30,16 @@ export async function installPackage(names: string | string[], options: InstallP
       args.unshift('--prefer-offline')
   }
 
-  if (agent === 'pnpm' && existsSync(resolve(options.cwd ?? process.cwd(), 'pnpm-workspace.yaml')))
-    args.unshift('-w')
+  if (agent === 'pnpm' && existsSync(resolve(options.cwd ?? process.cwd(), 'pnpm-workspace.yaml'))) {
+    args.unshift(
+      '-w',
+      /**
+       * Prevent pnpm from removing installed devDeps while `NODE_ENV` is `production`
+       * @see https://pnpm.io/cli/install#--prod--p
+       */
+      '--prod=false',
+    )
+  }
 
   return x(
     agent,


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This PR adds an args `--prod=false` to `installPackage` function for pnpm.

Prevent it from removing installed devDeps while `NODE_ENV` is `production`

### Linked Issues

Fix #18

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

Refs:

- https://pnpm.io/cli/install#--prod--p

### Besides

`@iconify/utils` and `@unocss/preset-icons` need to be updated after this is addressed.

I'm encountering this from using `unocss`.
