### PR TITLE
fix: avoid removing `devDependencies` when `NODE_ENV` is set to `production` without using a pnpm workspace.

### DIFF
--- a/src/install.ts
+++ b/src/install.ts
@@ -32,15 +32,17 @@ export async function installPackage(names: string | string[], options: InstallP
       args.unshift('--prefer-offline')
   }
 
-  if (agent === 'pnpm' && existsSync(resolve(options.cwd ?? process.cwd(), 'pnpm-workspace.yaml'))) {
+  if (agent === 'pnpm') {
     args.unshift(
-      '-w',
       /**
        * Prevent pnpm from removing installed devDeps while `NODE_ENV` is `production`
        * @see https://pnpm.io/cli/install#--prod--p
        */
       '--prod=false',
     )
+    if (existsSync(resolve(options.cwd ?? process.cwd(), 'pnpm-workspace.yaml'))) {
+      args.unshift('-w')
+    }
   }
 
   return x(


### PR DESCRIPTION
…uction` without using a pnpm workspace.

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Even if the pnpm workspace is not used, `devDependencies` should still be retained.

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
